### PR TITLE
v0.3.0

### DIFF
--- a/src/main/java/org/yj/sejongauth/controller/Sj.java
+++ b/src/main/java/org/yj/sejongauth/controller/Sj.java
@@ -1,19 +1,23 @@
 package org.yj.sejongauth.controller;
 
 import org.yj.sejongauth.domain.AuthService;
-import org.yj.sejongauth.domain.LoginReq;
-import org.yj.sejongauth.domain.ProfileRes;
+import org.yj.sejongauth.domain.SjProfile;
 import org.yj.sejongauth.domain.ProfileService;
 
 public class Sj {
 
-    private static final AuthService authService = new AuthService();
-    private static final ProfileService PROFILE_SERVICE = new ProfileService();
+    private final AuthService authService;
+    private final ProfileService profileService;
 
-    public static ProfileRes login(LoginReq loginReq) {
-        if (authService.authenticate(loginReq)) {
+    public Sj(AuthService authService, ProfileService profileService){
+        this.authService = authService;
+        this.profileService = profileService;
+    }
+
+    public SjProfile login(String userId, String password) {
+        if (authService.authenticate(userId, password)) {
             String jsessionId = authService.getJsessionId();
-            return PROFILE_SERVICE.fetchUserProfile(jsessionId);
+            return profileService.fetchUserProfile(jsessionId);
         } else {
             throw new RuntimeException("인증에 실패하였습니다.");
         }

--- a/src/main/java/org/yj/sejongauth/domain/AuthService.java
+++ b/src/main/java/org/yj/sejongauth/domain/AuthService.java
@@ -19,7 +19,8 @@ public class AuthService {
     private final String INVALID_URL = "URL이 유효하지 않습니다.";
     private final String CONTAINS_HTML = "로그인 정보가 올바르지 않습니다.";
 
-    public boolean authenticate(LoginReq loginReq) {
+    public boolean authenticate(String userId, String password) {
+        LoginReq loginReq = new LoginReq(userId, password);
         try {
             fetchJsessionId();
             return attemptLogin(loginReq);

--- a/src/main/java/org/yj/sejongauth/domain/ProfileService.java
+++ b/src/main/java/org/yj/sejongauth/domain/ProfileService.java
@@ -12,7 +12,7 @@ public class ProfileService {
     private final String PROFILE_URL = "http://classic.sejong.ac.kr/userCertStatus.do?menuInfoId=MAIN_02_05";
     private final String FAIDED_PROFILE = "정보 조회에 실패하였습니다.";
 
-    public ProfileRes fetchUserProfile(String jsessionId) {
+    public SjProfile fetchUserProfile(String jsessionId) {
         try {
             URL url = new URL(PROFILE_URL);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -37,7 +37,7 @@ public class ProfileService {
         }
     }
 
-    private ProfileRes parseProfileFromHtml(Document document) {
+    private SjProfile parseProfileFromHtml(Document document) {
         String major = document.select("div.contentWrap li dl dd").get(0).text();
         String studentCode = document.select("div.contentWrap li dl dd").get(1).text();
         String name = document.select("div.contentWrap li dl dd").get(2).text();
@@ -46,6 +46,6 @@ public class ProfileService {
         int completedSemesters = Integer.parseInt(document.select("div.contentWrap li dl dd").get(5).text().split(" ")[0]);
         int verifiedSemesters = Integer.parseInt(document.select("div.contentWrap li dl dd").get(6).text().split(" ")[0]);
 
-        return new ProfileRes(major, studentCode, name, gradeLevel, userStatus, completedSemesters, verifiedSemesters);
+        return new SjProfile(major, studentCode, name, gradeLevel, userStatus, completedSemesters, verifiedSemesters);
     }
 }

--- a/src/main/java/org/yj/sejongauth/domain/SjProfile.java
+++ b/src/main/java/org/yj/sejongauth/domain/SjProfile.java
@@ -1,6 +1,6 @@
 package org.yj.sejongauth.domain;
 
-public class ProfileRes {
+public class SjProfile {
     private final String major;
     private final String studentCode;
     private final String name;
@@ -9,9 +9,9 @@ public class ProfileRes {
     private final int completedSemesters;
     private final int verifiedSemesters;
 
-    public ProfileRes(String major, String studentCode, String name,
-                      int gradeLevel, String userStatus,
-                      int completedSemesters, int verifiedSemesters) {
+    public SjProfile(String major, String studentCode, String name,
+                     int gradeLevel, String userStatus,
+                     int completedSemesters, int verifiedSemesters) {
         this.major = major;
         this.studentCode = studentCode;
         this.name = name;

--- a/src/test/java/org/yj/sejongauth/domain/ProfileServiceTest.java
+++ b/src/test/java/org/yj/sejongauth/domain/ProfileServiceTest.java
@@ -22,7 +22,7 @@ class ProfileServiceTest {
         String jsessionId = "valid-session-id";
 
         // When
-        ProfileRes profile = profileService.fetchUserProfile(jsessionId);
+        SjProfile profile = profileService.fetchUserProfile(jsessionId);
 
         // Then
         assertNotNull(profile);


### PR DESCRIPTION
## 1. Spring의 Compoent의 도움을 받아 패키지 내 의존성 주입방식을 생성자 주입 방식으로 변경
```
@Configuration
@ComponentScan("org.yj.sejongauth")
public class AutoConfig {
}
```

## 2. 변수명 변경

ProfileRes - > SjProfile

## 3. 사용방식 간편화

기존 LoginRes 내 인자를 전부 알고 사용해야됨. -> Login(아이디, 패스워드) 진행방식으로 변경

### 한계점
1.  인수가 많아질 경우 복잡하고 사용하기 불편함. 그러나 세종대 로그인 방식이 향후 바뀌지 않을거라고 판단하기에 단순 인자 주입으로 선택.
2. 통일성 부족. LoginRes를 몰라도 사용가능하다는 점이 있으나 반대로 SjProfile을 반환값으로 가져오기에 SjProfile의 변수를 알아야됨.

### 